### PR TITLE
fix: lint warnings on GivenAndUsing rule

### DIFF
--- a/input/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/input/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -5,6 +5,8 @@ rule = GivenAndUsing
 package fix
 
 // format: off
+import scala.language.implicitConversions
+
 object GivenAndUsingTest {
   trait Foo[A]
 
@@ -15,5 +17,20 @@ object GivenAndUsingTest {
   class Bar[A](i:Int)(implicit foo: Foo[A], s: String) {
     def f(implicit iFoo: Foo[Int], sFoo: Foo[String]): Unit = ???
   }
+  trait Show[A] {
+    def show[A](a: A): String
+  }
+  object Show {
+    def apply[A](implicit ev: Show[A]): Show[A] = ev
+  }
+  case class Magnet(s: String)
+  implicit def showWithArg[A: Show](a:A): Magnet = Magnet(Show[A].show(a))/* assert: GivenAndUsing
+                                    ^^^
+  Unable to rewrite to `given` syntax because we found a function with a non implicit argument.
+*/
+  implicit def showWithArgs[A: Show](a: A, s: String): Magnet = Magnet(Show[A].show(a))/* assert: GivenAndUsing
+                                     ^^^^^^^^^^^^^^^
+  Unable to rewrite to `given` syntax because we found a function with a non implicit argument.
+  */
 }
 // format: on

--- a/input/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/input/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -32,5 +32,8 @@ object GivenAndUsingTest {
                                      ^^^^^^^^^^^^^^^
   Unable to rewrite to `given` syntax because we found a function with a non implicit argument.
   */
+  def untypedImplicit[A](foo: Foo[A]): Unit = {
+    implicit val fooOfA = foo// assert: GivenAndUsing
+  }
 }
 // format: on

--- a/input/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/input/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -13,6 +13,7 @@ object GivenAndUsingTest {
   implicit val fooInt: Foo[Int] = new Foo[Int] {}
   implicit def fooString: Foo[String] = new Foo[String] {}
   implicit def foo(implicit fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
+  implicit def fooUsing(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
 
   class Bar[A](i:Int)(implicit foo: Foo[A], s: String) {
     def f(implicit iFoo: Foo[Int], sFoo: Foo[String]): Unit = ???

--- a/input/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/input/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -12,6 +12,7 @@ object GivenAndUsingTest {
 
   implicit val fooInt: Foo[Int] = new Foo[Int] {}
   implicit def fooString: Foo[String] = new Foo[String] {}
+  implicit def fooParam[A: Foo]: Foo[List[A]] = new Foo[List[A]] {}
   implicit def foo(implicit fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
   implicit def fooUsing(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
 

--- a/output/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/output/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -9,6 +9,7 @@ object GivenAndUsingTest {
   given fooInt: Foo[Int] = new Foo[Int] {}
   given fooString: Foo[String] = new Foo[String] {}
   given foo(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
+  given fooUsing(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
 
   class Bar[A](i:Int)(using foo: Foo[A], s: String) {
     def f(using iFoo: Foo[Int], sFoo: Foo[String]): Unit = ???

--- a/output/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/output/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -1,6 +1,8 @@
 package fix
 
 // format: off
+import scala.language.implicitConversions
+
 object GivenAndUsingTest {
   trait Foo[A]
 
@@ -11,5 +13,14 @@ object GivenAndUsingTest {
   class Bar[A](i:Int)(using foo: Foo[A], s: String) {
     def f(using iFoo: Foo[Int], sFoo: Foo[String]): Unit = ???
   }
+  trait Show[A] {
+    def show[A](a: A): String
+  }
+  object Show {
+    def apply[A](using ev: Show[A]): Show[A] = ev
+  }
+  case class Magnet(s: String)
+  implicit def showWithArg[A: Show](a:A): Magnet = Magnet(Show[A].show(a))
+  implicit def showWithArgs[A: Show](a: A, s: String): Magnet = Magnet(Show[A].show(a))
 }
 // format: on

--- a/output/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/output/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -8,6 +8,7 @@ object GivenAndUsingTest {
 
   given fooInt: Foo[Int] = new Foo[Int] {}
   given fooString: Foo[String] = new Foo[String] {}
+  given fooParam[A: Foo]: Foo[List[A]] = new Foo[List[A]] {}
   given foo(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
   given fooUsing(using fooInt: Foo[Int]): Foo[Long] = new Foo[Long] {}
 

--- a/output/src/main/scala-3/fix/GivenAndUsingTest.scala
+++ b/output/src/main/scala-3/fix/GivenAndUsingTest.scala
@@ -22,5 +22,8 @@ object GivenAndUsingTest {
   case class Magnet(s: String)
   implicit def showWithArg[A: Show](a:A): Magnet = Magnet(Show[A].show(a))
   implicit def showWithArgs[A: Show](a: A, s: String): Magnet = Magnet(Show[A].show(a))
+  def untypedImplicit[A](foo: Foo[A]): Unit = {
+    implicit val fooOfA = foo
+  }
 }
 // format: on

--- a/rules/src/main/scala/fix/GivenAndUsing.scala
+++ b/rules/src/main/scala/fix/GivenAndUsing.scala
@@ -28,8 +28,8 @@ class GivenAndUsing extends SemanticRule("GivenAndUsing") {
         else Patch.lint(GivenValWithoutDeclaredType(v))
       case d: Defn.Def =>
         List(
-          if (d.mods.exists(_.is[Mod.Implicit]))
-            if (onlyImplicitParams(d)) replaceWithGiven(d, "def")
+          if (d.mods.exists(m => m.is[Mod.Implicit]))
+            if (onlyImplicitOrUsingParams(d)) replaceWithGiven(d, "def")
             else Patch.lint(GivenFunctionWithArgs(d))
           else Patch.empty,
           replaceWithUsing(d.paramss)
@@ -39,8 +39,8 @@ class GivenAndUsing extends SemanticRule("GivenAndUsing") {
     }.asPatch
   }
 
-  private def onlyImplicitParams(d: Defn.Def): Boolean =
-    d.paramss.forall(_.forall(_.mods.exists(_.is[Mod.Implicit])))
+  private def onlyImplicitOrUsingParams(d: Defn.Def): Boolean =
+    d.paramss.forall(_.forall(_.mods.exists(m => m.is[Mod.Implicit] || m.is[Mod.Using])))
 
   private def replaceWithUsing(paramss: List[List[Term.Param]]) = {
     paramss.flatten


### PR DESCRIPTION
A workaround for now. Look into if we actually can rewrite this case to given-using syntax.